### PR TITLE
Fix: clarify client command usage

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -35,8 +35,9 @@ ANTHROPIC_API_KEY=sk-ant-api03-put-your-private-key-here
 
 Then, run the demo TMCP client in the `client` directory with:
 
-```
-uv run client.py did:web:did.teaspoon.world:the:servers:did:here
+```bash
+# Replace <server-did> with the DID of the target server
+uv run client.py <server-did>
 ```
 
 It should list the available MCP tools from the demo MCP server. You should be able to enter a query to prompt it to use these tools.


### PR DESCRIPTION
Just a small thought.

when I was testing the demo, my server DID was e.g. `did:webvh:QmUkLBa8Bhk52wfFehPnkE4qEmHsRdxUMQ72dB6o5BmW7j:did.teaspoon.world:endpoint:DemoTmcpClient-be7da850-2535-4684-8a0a-20b628787304`. 

The original doc confused me a little because I’m using `did:webvh`, not `did:web`. So I made this change.