### PR TITLE
Add Decentralized Authentic Time service as a demo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "demo/server-gmail"]
 	path = demo/server-gmail
 	url = https://github.com/openwallet-foundation-labs/gmail-mcp-server
+[submodule "demo/decentralized-authentic-time-server"]
+	path = demo/decentralized-authentic-time-server
+	url = https://github.com/bakayu/mcp-simple-timeserver.git


### PR DESCRIPTION
Closes: https://github.com/openwallet-foundation-labs/tsp/issues/162
This PR adds [bakayu/mcp-simple-timeserver](https://github.com/bakayu/mcp-simple-timeserver) as a submodule, which is a mcp-time-server that runs over TMCP.

TO-DO:
- [x] Port [bakayu/mcp-simple-timeserver](https://github.com/bakayu/mcp-simple-timeserver) to run over TMCP.